### PR TITLE
Tweak to <esc>

### DIFF
--- a/XSVim.Tests/MiscTests.fs
+++ b/XSVim.Tests/MiscTests.fs
@@ -94,3 +94,7 @@ module ``Miscellaneous tests`` =
     [<Test>]
     let ``~ toggles case of selection``() =
         assertText "A$bC abc" "vll~" "a$Bc abc"
+
+    [<Test>]
+    let ``<esc> doesn't move caret left onto newline'``() =
+        assertText "A$bC abc" "o<esc>" "AbC abc\n$"

--- a/XSVim/XSVim.fs
+++ b/XSVim/XSVim.fs
@@ -153,7 +153,12 @@ module VimHelpers =
                 editor.CaretOffset + 1
             else
                 editor.CaretOffset
-        | Left -> editor.CaretOffset, if editor.CaretColumn > DocumentLocation.MinColumn then editor.CaretOffset - 1 else editor.CaretOffset
+        | Left ->
+           editor.CaretOffset,
+           if editor.CaretColumn > DocumentLocation.MinColumn && editor.Text.[editor.CaretOffset-1] <> '\n' then
+               editor.CaretOffset - 1
+           else
+               editor.CaretOffset
         | Up ->
             editor.CaretOffset,
             if editor.CaretLine > DocumentLocation.MinLine then


### PR DESCRIPTION
* Prevents caret from moving over newline when pressing <esc>
* I noticed the issue after seeing the caret move to the previous line after pressing `o<esc>`