### PR TITLE
Tweaks parsing for FindChars F, f, T, and t

### DIFF
--- a/XSVim.Tests/Movement.fs
+++ b/XSVim.Tests/Movement.fs
@@ -1,5 +1,4 @@
-﻿
-namespace XSVim.Tests
+﻿namespace XSVim.Tests
 open NUnit.Framework
 
 [<TestFixture>]
@@ -59,3 +58,19 @@ module ``Movement tests`` =
     [<Test>]
     let ``Does not move right past delimiter``() =
         assertText "a$b\n" "ll" "ab$\n"
+
+    [<Test>]
+    let ``Find moves to digit``() =
+        assertText "abc$ d1 d2 d3" "f2" "abc d1 d2$ d3"
+
+    [<Test>]
+    let ``Reverse find moves to digit``() =
+        assertText "abc d1 d2 d$3" "F1" "abc d1$ d2 d3"
+
+    [<Test>]
+    let ``Till moves to digit``() =
+        assertText "abc$ d1 d2 d3" "t2" "abc d1 d$2 d3"
+
+    [<Test>]
+    let ``Reverse till moves to digit``() =
+        assertText "abc d1 d2 d$3" "T1" "abc d1 $d2 d3"

--- a/XSVim/XSVim.fs
+++ b/XSVim/XSVim.fs
@@ -686,6 +686,7 @@ module Vim =
         let numericArgument, keyList =
             match keyList with
             | "r" :: _ -> None, keyList
+            | FindChar _ :: _ -> None, keyList
             // 2dw -> 2, dw
             | OneToNine d1 :: Digit d2 :: Digit d3 :: Digit d4 :: t ->
                 Some (d1 * 1000 + d2 * 100 + d3 * 10 + d4), t


### PR DESCRIPTION
* This adjusts the parsing for the `FindChars` so that it can find digits 
* Adds unit tests
* Fixes https://github.com/nosami/XSVim/issues/63