### PR TITLE
Adds basic marks implementation

### DIFF
--- a/XSVim.Tests/Movement.fs
+++ b/XSVim.Tests/Movement.fs
@@ -118,3 +118,11 @@ module ``Movement tests`` =
     [<Test>]
     let ``gE moves back to end of last WORD``() =
         assertText "abc def.gh$i" "gE" "abc$ def.ghi"
+
+    [<Test>]
+    let ``mark returns to position on same line``() =
+        assertText "ab$c def" "malll`a" "ab$c def"
+
+    [<Test>]
+    let ``mark returns to position on new line``() =
+        assertText "ab$c\ndef\nghi" "mzjjl`z" "ab$c\ndef\nghi"

--- a/XSVim.Tests/Movement.fs
+++ b/XSVim.Tests/Movement.fs
@@ -118,11 +118,3 @@ module ``Movement tests`` =
     [<Test>]
     let ``gE moves back to end of last WORD``() =
         assertText "abc def.gh$i" "gE" "abc$ def.ghi"
-
-    [<Test>]
-    let ``mark returns to position on same line``() =
-        assertText "ab$c def" "malll`a" "ab$c def"
-
-    [<Test>]
-    let ``mark returns to position on new line``() =
-        assertText "ab$c\ndef\nghi" "mzjjl`z" "ab$c\ndef\nghi"

--- a/XSVim/Properties/AddinInfo.fs
+++ b/XSVim/Properties/AddinInfo.fs
@@ -5,7 +5,7 @@ open MonoDevelop
 [<assembly:Addin (
   "XSVim", 
   Namespace = "XSVim",
-  Version = "0.26.3"
+  Version = "0.27.0"
 )>]
 
 [<assembly:AddinName ("Vim")>]

--- a/XSVim/Types.fs
+++ b/XSVim/Types.fs
@@ -1,9 +1,14 @@
-﻿namespace XSVim
+namespace XSVim
 open System
 
 type BeforeOrAfter = Before | After | OverSelection
 
 type CaretMode = Insert | Block
+
+type MarkLocation = {
+    offset: int
+    fileName: string
+}
 
 type Register = 
     |Register of Char
@@ -41,7 +46,6 @@ type CommandType =
     | IncrementNumber
     | DecrementNumber
     | SetMark of string
-    | GoToMark of string
 
 type TextObject =
     | Character
@@ -93,16 +97,12 @@ type TextObject =
     | SelectedText
     | SelectionStart
     | MatchingBrace
+    | ToMark of MarkLocation
 
 type VimAction = {
     repeat: int option
     commandType: CommandType
     textObject: TextObject
-}
-
-type MarkLocation = {
-    offset: int
-    fileName: string
 }
 
 type VimState = {
@@ -114,7 +114,6 @@ type VimState = {
     desiredColumn: int option
     undoGroup: IDisposable option
     statusMessage: string option
-    markMap: System.Collections.Generic.Dictionary<string, MarkLocation>
 }
 
 // shim for the build server which runs Mono 4.6.1

--- a/XSVim/Types.fs
+++ b/XSVim/Types.fs
@@ -40,6 +40,8 @@ type CommandType =
     | InsertChar of string
     | IncrementNumber
     | DecrementNumber
+    | SetMark of string
+    | GoToMark of string
 
 type TextObject =
     | Character
@@ -98,6 +100,11 @@ type VimAction = {
     textObject: TextObject
 }
 
+type MarkLocation = {
+    offset: int
+    fileName: string
+}
+
 type VimState = {
     keys: string list
     mode: VimMode
@@ -107,6 +114,7 @@ type VimState = {
     desiredColumn: int option
     undoGroup: IDisposable option
     statusMessage: string option
+    markMap: System.Collections.Generic.Dictionary<string, MarkLocation>
 }
 
 // shim for the build server which runs Mono 4.6.1


### PR DESCRIPTION
### This is not quite ready to merge; I'm opening to facilitate discussion.  The code is working but the new tests are failing.
This seems to work well for setting/jumping to marks within the same file as well as into other files.  There are a few things I had questions on though:
* Would you recommend using another data structure instead of a `Dictionary`?  I was thinking `Map`s but couldn't get them working quite right.
* Would you recommend moving the `markDict` out of `Types.fs` and into the global state in the `Vim` module?
* The new unit tests fail with a `NullReferenceException`.  I think it may be due to improperly setting up the dictionary in the test runner, but I may need to play around with it a bit more.