### PR TITLE
Fix for `aw` and handling of `S`

### DIFF
--- a/XSVim.Tests/ChangeTests.fs
+++ b/XSVim.Tests/ChangeTests.fs
@@ -38,3 +38,11 @@ module ``Change tests`` =
     [<Test>]
     let ``ci backtick``() =
         assertText "``some t$ext``" "ci`" "``|``"
+
+    [<Test>]
+    let ``S changes entire line``() =
+        assertText " line1 \n line2$ \n line3 " "S" " line1 \n|\n line3 "
+
+    [<Test>]
+    let ``2S changes two lines``() =
+        assertText " line1 \n line2$ \n line3 \n line4 " "2S" " line1 \n|\n line4 "

--- a/XSVim.Tests/Movement.fs
+++ b/XSVim.Tests/Movement.fs
@@ -109,7 +109,7 @@ module ``Movement tests`` =
 
     [<Test>]
     let ``ge between words moves back to end of last word``() =
-        assertText "abc $def" "ge" "abc$ def"
+        assertText "abc  $def" "ge" "abc$  def"
 
     [<Test>]
     let ``ge stops at first character``() =

--- a/XSVim.Tests/TextObjectSelectionTests.fs
+++ b/XSVim.Tests/TextObjectSelectionTests.fs
@@ -1,0 +1,23 @@
+﻿namespace XSVim.Tests
+open NUnit.Framework
+
+[<TestFixture>]
+module ``Text object selection tests`` =
+
+    // Tests for aw. Reference: http://vimdoc.sourceforge.net/htmldoc/motion.html#aw
+
+    [<Test>]
+    let ``daw on a word``() =
+        assertText "word1   word2$   word3" "daw" "word1   w$ord3" // three spaces before word2 preserved, two after removed
+
+    [<Test>]
+    let ``daw from whitespace before a word``() =
+        assertText "word1  $  word2   word3" "daw" "word1 $  word3" // four spaces before word2 removed, three after preserved
+
+    [<Test>]
+    let ``aw stops searching at EOL``() =
+        assertText "word1$    \n word2" "daw" "\n$ word2"
+
+    [<Test>]
+    let ``caw on a word``() =
+        assertText "word1   word2$  word3" "caw" "word1   |word3"

--- a/XSVim.Tests/XSVim.Tests.fsproj
+++ b/XSVim.Tests/XSVim.Tests.fsproj
@@ -78,6 +78,7 @@
 		<Compile Include="YankAndPut.fs" />
 		<Compile Include="ChangeTests.fs" />
 		<Compile Include="InsertionTests.fs" />
+		<Compile Include="TextObjectSelectionTests.fs" />
 	</ItemGroup>
 	<Import Project="$(FSharpTargetsPath)" />
 </Project>

--- a/XSVim/XSVim.fs
+++ b/XSVim/XSVim.fs
@@ -898,6 +898,7 @@ module Vim =
             | NormalMode, [ "x" ] -> [ run Delete CurrentLocation ]
             | NormalMode, [ "X" ] -> [ run DeleteLeft Nothing ]
             | NormalMode, [ "s"] -> [ run Delete CurrentLocation; switchMode InsertMode ]
+            | NormalMode, [ "S"] -> [ run Delete WholeLineIncludingDelimiter; runOnce (InsertLine After) Nothing; switchMode InsertMode ]
             | NormalMode, [ "p" ] -> [ run (Put After) Nothing ]
             | NormalMode, [ "P" ] -> [ run (Put Before) Nothing ]
             | VisualModes, [ "p" ] -> [ run (Put OverSelection) Nothing ]


### PR DESCRIPTION
By my mistake, this PR has two commits:

### 1. Current implementation doesn't handle whitespace surrounding `a word` correctly.

Also, a fix for a subtle bug in `findWordBackwards`: current implementation would stop
working when traversing back more than one whitespace. Should be "-" instead of "+".
See the changes to the test ``ge between words moves back to end of last word``.

### 2. Handling of S: delete line and put in insert mode

Essentially, an alias to `ddo`.
