### PR TITLE
Fix ctrl-w, c close tab behaviour

### DIFF
--- a/XSVim/Properties/AddinInfo.fs
+++ b/XSVim/Properties/AddinInfo.fs
@@ -5,7 +5,7 @@ open MonoDevelop
 [<assembly:Addin (
   "XSVim", 
   Namespace = "XSVim",
-  Version = "0.36.0"
+  Version = "0.36.1"
 )>]
 
 [<assembly:AddinName ("Vim")>]

--- a/XSVim/XSVim.fs
+++ b/XSVim/XSVim.fs
@@ -1240,7 +1240,7 @@ module Vim =
             | NotInsertMode, [ "<C-w>"; "l" ] -> [ func Window.rightWindow ]
             // These commands don't work the same way as vim yet, but better than nothing
             | NotInsertMode, [ "<C-w>"; "o" ] -> [ dispatch FileTabCommands.CloseAllButThis ]
-            | NotInsertMode, [ "<C-w>"; "c" ] -> [ dispatch FileCommands.CloseFile ]
+            | NotInsertMode, [ "<C-w>"; "c" ] -> [ func Window.closeTab ]
             | NotInsertMode, [ "<C-w>"; "v" ]
             | NotInsertMode, [ "<C-w>"; "s" ] 
             | NotInsertMode, [ "<C-w>"; "<C-v>" ]


### PR DESCRIPTION
When closing the only tab in a split, the other split gets focus, otherwise the tab to the left is given focus.