### PR TITLE
Don't automatically remove commands

### DIFF
--- a/XSVim/Addin.fs
+++ b/XSVim/Addin.fs
@@ -1,6 +1,7 @@
 ﻿namespace XSVim
 
 open System
+open System.Collections.Generic
 open MonoDevelop.Components.Commands
 open MonoDevelop.Core
 open MonoDevelop.Ide
@@ -171,7 +172,7 @@ type XSVim() as this =
     member x.NavigateBackwards() = ctrl "o"
 
     [<CommandHandler ("XSVim.NavigateForwards")>]
-    member x.NavigateForwards() = ctrl "p"
+    member x.NavigateForwards() = ctrl "i"
 
     [<CommandHandler ("XSVim.IncrementNumber")>]
     member x.IncrementNumber() = ctrl "x"

--- a/XSVim/Addin.fs
+++ b/XSVim/Addin.fs
@@ -1,6 +1,6 @@
 ﻿namespace XSVim
+
 open System
-open System.Collections.Generic
 open MonoDevelop.Components.Commands
 open MonoDevelop.Core
 open MonoDevelop.Ide
@@ -8,7 +8,7 @@ open MonoDevelop.Ide.Editor
 open MonoDevelop.Ide.Editor.Extension
 open MonoDevelop.Ide.FindInFiles
 
-type XSVim() =
+type XSVim() as this =
     inherit TextEditorExtension()
     let mutable disposables : IDisposable list = []
     let mutable processingKey = false
@@ -25,6 +25,7 @@ type XSVim() =
                            } |> Some }
         else
             config <- { insertModeEscapeKey = None }
+
 
     let initializeSearchResultsPads() =
         IdeApp.Workbench
@@ -43,6 +44,10 @@ type XSVim() =
                             searchResultsPad.initialize pad)
                 with
                 | _ -> ()))
+
+    let ctrl c =
+        KeyDescriptor.FromGtk(Enum.Parse(typeof<Gdk.Key>, c) :?> Gdk.Key, char c, Gdk.ModifierType.ControlMask)
+        |> this.KeyPress
 
     member x.FileName = x.Editor.FileName.FullPath.ToString()
 
@@ -144,6 +149,38 @@ type XSVim() =
         // before the inline rename kicks in
         if x.State.mode <> InsertMode then
             x.State <- Vim.switchToInsertMode x.Editor x.State false
+
+    // Command handlers for all keys that possibly conflict with
+    // out of the box key binding schemes.
+    [<CommandHandler ("XSVim.HalfPageDown")>]
+    member x.HalfPageDown() = ctrl "d"
+
+    [<CommandHandler ("XSVim.PageDown")>]
+    member x.PageDown() = ctrl "f"
+
+    [<CommandHandler ("XSVim.PageUp")>]
+    member x.PageUp() = ctrl "b"
+
+    [<CommandHandler ("XSVim.FindFile")>]
+    member x.FindFile() = ctrl "p"
+
+    [<CommandHandler ("XSVim.DynamicAbbrev")>]
+    member x.DynamicAbbrev() = ctrl "n"
+
+    [<CommandHandler ("XSVim.NavigateBackwards")>]
+    member x.NavigateBackwards() = ctrl "o"
+
+    [<CommandHandler ("XSVim.NavigateForwards")>]
+    member x.NavigateForwards() = ctrl "p"
+
+    [<CommandHandler ("XSVim.IncrementNumber")>]
+    member x.IncrementNumber() = ctrl "x"
+
+    [<CommandHandler ("XSVim.DecrementNumber")>]
+    member x.DecrementNumber() = ctrl "a"
+
+    [<CommandHandler ("XSVim.Escape")>]
+    member x.Escape() = ctrl "c"
 
     override x.Dispose() =
         base.Dispose()

--- a/XSVim/KeyBindingSchemeVim.xml
+++ b/XSVim/KeyBindingSchemeVim.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<scheme version="1.0">
+    <!-- Vim keybinding scheme containing all the keys that
+         conflict with keybindings in the Visual Studio keybinding scheme-->
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.DeleteRightChar" shortcut="" />
+    <binding command="XSVim.HalfPageDown" shortcut="Control+D" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.LineUp" shortcut="" />
+    <binding command="XSVim.FindFile" shortcut="Control+P" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.CharRight" shortcut="" />
+    <binding command="XSVim.PageDown" shortcut="Control+F" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.CharLeft" shortcut="" />
+    <binding command="XSVim.PageUp" shortcut="Control+B" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.LineDown" shortcut="" />
+    <binding command="XSVim.DynamicAbbrev" shortcut="Control+N" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.InsertNewLinePreserveCaretPosition" shortcut="" />
+    <binding command="XSVim.NavigateBackwards" shortcut="Control+O" />
+    <binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="" />
+    <binding command="XSVim.NavigateForwards" shortcut="Control+I" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.LineStart" shortcut = "Meta+Left"/> <!-- removed ctrl-a -->
+    <binding command="XSVim.DecrementNumber" shortcut="Control+A" />
+    <binding command="XSVim.IncrementNumber" shortcut="Control+X" />
+    <binding command="XSVim.Escape" shortcut="Escape Control+C Control+[" />
+</scheme>

--- a/XSVim/Properties/AssemblyInfo.fs
+++ b/XSVim/Properties/AssemblyInfo.fs
@@ -5,7 +5,7 @@ open System.Runtime.CompilerServices
 [<AutoOpen>]
 module AddinVersion =
     [<Literal>]
-    let version = "0.54.7"
+    let version = "0.55.0"
 
 [<assembly: AssemblyTitle("XSVim")>]
 // The assembly version has the format {Major}.{Minor}.{Build}.{Revision}

--- a/XSVim/Properties/Manifest.addin.xml
+++ b/XSVim/Properties/Manifest.addin.xml
@@ -1,19 +1,37 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
-	<Runtime>
-	</Runtime>
+    <Runtime>
+    </Runtime>
     <Extension path="/MonoDevelop/Ide/TextEditorExtensions">
         <Class class="XSVim.XSVim" />
     </Extension>
     <Extension path = "/MonoDevelop/Ide/Commands">
-        <Command id = "MonoDevelop.Ide.Commands.EditCommands.Undo"
-            _label = "_Undo"
-            icon = "gtk-undo"
-            _description = "Undo (vim)"
-            shortcut = "Control|Z"
-            macShortcut = "Meta|Z" />
+        <Category _name = "Vim" id = "Vim" >
+            <!-- Override undo to use the vim undo stack -->
+            <Command id = "MonoDevelop.Ide.Commands.EditCommands.Undo"
+                _label = "_Undo"
+                icon = "gtk-undo"
+                _description = "Undo (vim)"
+                shortcut = "Control|Z"
+                macShortcut = "Meta|Z" />
+            <!-- Commands that may conflict with built in keybinding schemes -->
+            <Command id="XSVim.HalfPageDown" _label="Half page down" _description="Move half a page down" shortcut="Control|D" />
+            <Command id="XSVim.FindFile" _label="Find file" shortcut="Control|P" />
+            <Command id="XSVim.PageDown" _label="Page down" shortcut="Control|F" />
+            <Command id="XSVim.PageUp" _label="Page up" shortcut="Control|B" />
+            <Command id="XSVim.DynamicAbbrev" _label="Complete from file" shortcut="Control|N" />
+            <Command id="XSVim.NavigateBackwards" _label="Navigate Backwards" shortcut="Control|O" />
+            <Command id="XSVim.NavigateForwards" _label="Navigate Forwards" shortcut="Control|I" />
+            <Command id="XSVim.NavigateForwards" _label="Navigate Forwards" shortcut="Control|I" />
+            <Command id="XSVim.IncrementNumber" _label="Increment Number" shortcut="Control|X" />
+            <Command id="XSVim.DecrementNumber" _label="Decrement Number" shortcut="Control|A" />
+            <Command id="XSVim.Escape" _label="Return to normal mode" shortcut="Escape Control|C Control|[" />
+        </Category>
     </Extension>
     <Extension path="/MonoDevelop/Ide/GlobalOptionsDialog/Other">
         <Section id="VimSettings" _label="Vim Settings" class = "XSVim.SettingsPanel" icon="md-prefs-source" />
+    </Extension>
+    <Extension path = "/MonoDevelop/Ide/KeyBindingSchemes">
+        <Scheme id="Vim" _name = "Visual Studio + Vim" resource="KeyBindingSchemeVim.xml" forMac="true" />
     </Extension>
 </ExtensionModel>

--- a/XSVim/XSVim.fs
+++ b/XSVim/XSVim.fs
@@ -17,40 +17,8 @@ module VimHelpers =
     let commandManager = IdeApp.CommandService |> Option.ofObj
        
     let dispatchCommand command =
-
         commandManager
         |> Option.iter(fun c -> c.DispatchCommand command |> ignore)
-
-    let unregisterConflictingCommands() =
-        match commandManager, Platform.IsMac with
-        | Some commandManager', true ->
-            let commands = commandManager'.GetCommands() |> Array.ofSeq
-            [
-                "Control+P"
-                "Control+D"
-                "Control+U"
-                "Control+F"
-                "Control+B"
-                "Control+W"
-                "Control+V"
-                "Control+C"
-                "Control+R"
-                "Control+Y"
-                "Control+E"
-                "Control+A"
-                "Control+X"
-                "Control+N"
-                "Control+O"
-                "Control+I"
-                "Control+["
-            ]
-            |> List.iter(fun k ->
-                commands
-                |> Array.tryFind(fun command -> command.AccelKey = k)
-                |> Option.iter commandManager'.UnregisterCommand)
-
-        | _ -> ()
-    unregisterConflictingCommands()
 
     let closingBraces = [')'; '}'; ']'] |> set
     let openingbraces = ['('; '{'; '[' ] |> set

--- a/XSVim/XSVim.fsproj
+++ b/XSVim/XSVim.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="TreeViewPads.fs" />
     <Compile Include="XSVim.fs" />
     <Compile Include="Addin.fs" />
+    <EmbeddedResource Include="KeyBindingSchemeVim.xml" />
   </ItemGroup>
   <Import Project="$(FSharpTargetsPath)" />
 </Project>


### PR DESCRIPTION
Fixes #156

Create commands for all keybinds that may conflict with built in keybinding
schemes (Just Visual Studio for Mac default for now).

Also created Visual Studio + Vim keybinding scheme to set vim keys for users
that want that behaviour.